### PR TITLE
etc/shells: Add yash to login shells

### DIFF
--- a/etc/shells
+++ b/etc/shells
@@ -9,4 +9,5 @@
 /bin/sash
 /bin/sh
 /bin/tcsh
+/bin/yash
 /bin/zsh


### PR DESCRIPTION
I have been using yash as my login shell on both Gentoo and Slackware without issue for a while now. It would be nice to not have to worry about accidentally removing it from my `/etc/shells`  on Gentoo in the future.

See:

https://github.com/magicant/yash
https://packages.gentoo.org/packages/app-shells/yash