### PR TITLE
Relax checks on KEEPDIR when directories are mounted fs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ layout-dirs:
 	# Create base filesytem layout
 	for x in $(KEEP_DIRS) ; do \
 		test -e $(DESTDIR)$$x/.keep && continue ; \
-		$(INSTALL_DIR) $(DESTDIR)$$x || exit $$? ; \
+		$(INSTALL_DIR) $(DESTDIR)$$x || echo "ignoring install failure; mounted fs?" ; continue ; \
 		touch $(DESTDIR)$$x/.keep || echo "ignoring touch failure; mounted fs?" ; \
 	done
 


### PR DESCRIPTION
My use case for this is in containers (mkosi with systemd-nspawn in my
case)

Signed-off-by: Paymon <darwinskernel@gmail.com>