### PR TITLE
etc/issue: remove DNS domain name

### DIFF
--- a/etc/issue
+++ b/etc/issue
@@ -1,3 +1,3 @@
 
-This is \n.\O (\s \m \r) \t
+This is \n (\s \m \r) \t
 


### PR DESCRIPTION
It is very common for client systems to not have a valid DNS domain name. This results in agetty printing "unknown_domain", which may confuse new users.