### PR TITLE
share/fstab: modernize, drop reiserfs references, drop noatime

### DIFF
--- a/share/fstab
+++ b/share/fstab
@@ -17,6 +17,6 @@
 # <fs>			<mountpoint>	<type>		<opts>		<dump> <pass>
 
 #LABEL=boot		/boot		ext4		defaults	1 2
-#UUID=58e72203-57d1-4497-81ad-97655bd56494		/		ext4		defaults		0 1
+#UUID=58e72203-57d1-4497-81ad-97655bd56494		/		xfs		defaults		0 1
 #LABEL=swap		none		swap		sw		0 0
 #/dev/cdrom		/mnt/cdrom	auto		noauto,ro	0 0

--- a/share/fstab
+++ b/share/fstab
@@ -4,9 +4,6 @@
 #
 # See the manpage fstab(5) for more information.
 #
-
-# <fs>			<mountpoint>	<type>		<opts>		<dump/pass>
-
 #
 # NOTE: Even though we list ext4 as the type here, it will work with ext2/ext3
 #       filesystems.  This just tells the kernel to use the ext4 driver.
@@ -15,6 +12,8 @@
 #       more reliable to use filesystem labels or UUIDs. See your filesystem
 #       documentation for details on setting a label. To obtain the UUID, use
 #       the blkid(8) command.
+
+# <fs>			<mountpoint>	<type>		<opts>		<dump> <pass>
 
 #LABEL=boot		/boot		ext4		defaults	1 2
 #UUID=58e72203-57d1-4497-81ad-97655bd56494		/		ext4		defaults		0 1

--- a/share/fstab
+++ b/share/fstab
@@ -1,9 +1,10 @@
 # /etc/fstab: static file system information.
-# The root filesystem should have a pass number of either 0 or 1.
-# All other filesystems should have a pass number of 0 or greater than 1.
 #
 # See the manpage fstab(5) for more information.
 #
+#
+# NOTE: The root filesystem should have a pass number of either 0 or 1.
+#       All other filesystems should have a pass number of 0 or greater than 1.
 #
 # NOTE: Even though we list ext4 as the type here, it will work with ext2/ext3
 #       filesystems.  This just tells the kernel to use the ext4 driver.

--- a/share/fstab
+++ b/share/fstab
@@ -1,10 +1,4 @@
 # /etc/fstab: static file system information.
-#
-# noatime turns off atimes for increased performance (atimes normally aren't 
-# needed); notail increases performance of ReiserFS (at the expense of storage 
-# efficiency).  It's safe to drop the noatime options if you want and to 
-# switch between notail / tail freely.
-#
 # The root filesystem should have a pass number of either 0 or 1.
 # All other filesystems should have a pass number of 0 or greater than 1.
 #
@@ -13,7 +7,6 @@
 
 # <fs>			<mountpoint>	<type>		<opts>		<dump/pass>
 
-# NOTE: If your BOOT partition is ReiserFS, add the notail option to opts.
 #
 # NOTE: Even though we list ext4 as the type here, it will work with ext2/ext3
 #       filesystems.  This just tells the kernel to use the ext4 driver.
@@ -23,7 +16,7 @@
 #       documentation for details on setting a label. To obtain the UUID, use
 #       the blkid(8) command.
 
-#LABEL=boot		/boot		ext4		noauto,noatime	1 2
-#UUID=58e72203-57d1-4497-81ad-97655bd56494		/		ext4		noatime		0 1
+#LABEL=boot		/boot		ext4		defaults	1 2
+#UUID=58e72203-57d1-4497-81ad-97655bd56494		/		ext4		defaults		0 1
 #LABEL=swap		none		swap		sw		0 0
 #/dev/cdrom		/mnt/cdrom	auto		noauto,ro	0 0


### PR DESCRIPTION
ReiserFS was deprecated in Linux 5.18 and slated for removal in 2025.

Using 'noatime' does seldom really bring any noticeable performance benefit. The default of 'relatime', which Linux supports for a long time, is a good compromise. Having an (coarse-grained) atime allows for certain use cases. For example, a tool that detects unused packages in a system and suggest them for removal.

A generic configuration file like this should simply use the defaults. Especially if those are sane ones. No need to continue the noatime cargo cult.

Also split "<dump/pass>" into "<dump> <pass>", since those are two different fields (see fstab(5)).

Finally, we move the fstable table header right above the commented-out exmaple fstab entries.