### PR TITLE
Set net.ipv4.ping_group_range sysctl

### DIFF
--- a/lib/sysctl.d/40-ping_group_range.conf
+++ b/lib/sysctl.d/40-ping_group_range.conf
@@ -1,0 +1,5 @@
+# ping(8) without CAP_NET_ADMIN and CAP_NET_RAW
+# The upper limit is set to 2^31-1. Values greater than that get rejected by
+# the kernel because of this definition in linux/include/net/ping.h:
+#   #define GID_T_MAX (((gid_t)~0U) >> 1)
+-net.ipv4.ping_group_range = 0 2147483647


### PR DESCRIPTION
This will allow unprivileged users to use the ping command.

sysctl.d snippet taken from systemd.

Bug: https://bugs.gentoo.org/962112